### PR TITLE
Conditionally remove google-cloud-sdk

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       # If there is a problem with this GitHub Actions, this step will fail
       - name: Free Disk Space
-        uses: hirnidrin/free-disk-space@main
+        uses: jlumbroso/free-disk-space@main
         with:
           tool-cache: true
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       # If there is a problem with this GitHub Actions, this step will fail
       - name: Free Disk Space
-        uses: jlumbroso/free-disk-space@main
+        uses: descriptinc/free-disk-space@main
         with:
           tool-cache: true
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,6 @@ A customizable GitHub Actions to free disk space on Linux GitHub Actions runners
 
 On a typical Ubuntu runner, with all options turned on (or not turned off rather), this can clear up to 31 GB of disk space in about 3 minutes (the longest period is calling `apt` to uninstall packages). This is useful when you need a lot of disk space to run computations.
 
-Please don't hesitate to [submit issues](https://github.com/jlumbroso/free-disk-space/issues) to report problems or suggest new features (or sets of files to help remove).
-
-Also, please ⭐️ the repo if you like this GitHub Actions! Thanks! 😊
-
 ## Example
 
 ```yaml
@@ -20,7 +16,7 @@ jobs:
     steps:
 
     - name: Free Disk Space (Ubuntu)
-      uses: jlumbroso/free-disk-space@main
+      uses: descriptinc/free-disk-space@main
       with:
         # this might remove tools that are actually needed,
         # if set to "true" but frees about 6 GB

--- a/action.yml
+++ b/action.yml
@@ -171,8 +171,8 @@ runs:
         if [[ ${{ inputs.large-packages }} == 'true' ]]; then
           BEFORE=$(getAvailableSpace)
 
-          sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^aspnetcore-.*'
+          sudo apt-get remove -y '^dotnet-.*'
           sudo apt-get remove -y '^llvm-.*'
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'

--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-cloud-sdk google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y azure-cli google-cloud-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           sudo apt-get autoremove -y
           sudo apt-get clean
           

--- a/action.yml
+++ b/action.yml
@@ -177,7 +177,7 @@ runs:
           sudo apt-get remove -y 'php.*'
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
-          sudo apt-get remove -y azure-cli google-cloud-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
           sudo apt-get autoremove -y
           sudo apt-get clean
           

--- a/action.yml
+++ b/action.yml
@@ -178,6 +178,7 @@ runs:
           sudo apt-get remove -y '^mongodb-.*'
           sudo apt-get remove -y '^mysql-.*'
           sudo apt-get remove -y azure-cli google-chrome-stable firefox powershell mono-devel libgl1-mesa-dri
+          sudo apt-get remove -y google-cloud-sdk || sudo apt-get remove -y google-cloud-cli || true
           sudo apt-get autoremove -y
           sudo apt-get clean
           


### PR DESCRIPTION
- Addresses jlumbroso/free-disk-space#17. Try to remove `google-cloud-sdk`, and if it fails, try `google-cloud-cli`, and if that fails, just proceed.
- Previously unmerged change regarding `dotnet*` packages.
- Change references to the original repo to this one.